### PR TITLE
fix: python command not found

### DIFF
--- a/templates/send_slack_on_ssh_login.sh.j2
+++ b/templates/send_slack_on_ssh_login.sh.j2
@@ -17,7 +17,7 @@ else
 	  else
 	  {% endif %}
 		URL={{ ssh_login_notifications_slack_webhook }}
-		TEXT=$(echo -e "$PAM_SERVICE login on `hostname -s` for account *$PAM_USER* ($PAM_TTY)\n" | python -c "import json,sys;print(json.dumps(sys.stdin.read()))")
+		TEXT=$(echo -e "$PAM_SERVICE login on `hostname -s` for account *$PAM_USER* ($PAM_TTY)\n" | python3 -c "import json,sys;print(json.dumps(sys.stdin.read()))")
 		PAYLOAD="{
 		  \"attachments\": [
 			{


### PR DESCRIPTION
`python` could not be found on aws instance with ubuntu 16.04 or above, `python3` could be found after dependencies installation

just for a reminder