### PR TITLE
Add support for Ansible >=2.7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,14 +2,14 @@
 - name: Install open SSH server in the first place for this role to make any sense
   action: apt pkg='openssh-server' state=present install_recommends=no update-cache=yes
 
-- include: enable-mail-notifications.yml
+- include_tasks: enable-mail-notifications.yml
   when: ssh_login_notifications_mail_enable == true
 
-- include: enable-slack-notifications.yml
+- include_tasks: enable-slack-notifications.yml
   when: ssh_login_notifications_slack_enable == true
 
-- include: disable-mail-notifications.yml
+- include_tasks: disable-mail-notifications.yml
   when: ssh_login_notifications_mail_enable == false
 
-- include: disable-slack-notifications.yml
+- include_tasks: disable-slack-notifications.yml
   when: ssh_login_notifications_slack_enable == false


### PR DESCRIPTION
When running the role with Ansible >=2.7 it fails with the following message:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```

The proposed pr replaces all occurrences of `include:` with `include_tasks:`